### PR TITLE
Fixed very long code not assembling

### DIFF
--- a/assembler.js
+++ b/assembler.js
@@ -314,7 +314,7 @@ function SimulatorWidget(node) {
       if ((addr >= 0x0000) && (addr < 0xfe00)) {
         return memArray[addr] = val;
       } else {
-        return False;
+        return false;
       }
     }
 


### PR DESCRIPTION
Fixed a typo in assembler.js that stops extremely long code from assembling